### PR TITLE
Support server-side rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,40 +18,46 @@ And now you can easily bring the future of time to your React apps!
 
 ## Example usage
 
-```
+```jsx
 import useInternetTime from 'use-internet-time';
 
 const InternetClock = () => {
   const time = useInternetTime();
 
-  return <div>{`It's currently ${time} all over the world!`}</div>
-}
+  return <div>{`It's currently ${time} all over the world!`}</div>;
+};
 ```
 
 ## Usage
 
-```
+```jsx
 useInternetTime(
   options?: {
     fractional?: boolean,
-    ssr?: boolean
   }
 ): string
 ```
 
-`useInternetTime` accepts an options argument with two values:
+`useInternetTime` accepts an options argument with a single value:
 
 ### `fractional`
 
-> Default: `false` 
+> Default: `false`
 
 When true, returns a string formatted in long internet time (e.g. `@230.21`). When false, returns a string formatted in short internet time (e.g. `@230`)
 
-### `ssr`
+## Server-side rendering usage
 
-> Default: `false` 
+If you use `useInternetTime` with a server-side rendering framework like Gatsby or Next with `fractional` set to true, you're likely to see warnings in your console from React regarding mismatching text or mismatching values. You can silence these by setting `suppressHydrationWarning={true}` on the element where you're using `time`. For example:
 
-When true, `useInternetTime` will return an empty string on initial render instead of the current time. This makes `useInternetTime` server-side rendering-safe.
+```jsx
+import useInternetTime from 'use-internet-time';
 
-This prevents mis-match issues in server-side-rendered environments like Gatsby and Next, where network latency can result in webpage delivery between fractional beats. For example, the server might evaluate to `@230.21` but the client might evaluate to `@230.22`, causing React to error. Enabling this option will prevent this behavior.
+const SSRClock = () => {
+  const time = useInternetTime({ fractional: true });
 
+  return <div suppressHydrationWarning={true}>The time is: {time}</div>;
+};
+```
+
+This is an escape hatch from React DOM to help suppress mismatching values that cannot be avoided (e.g. timestamps), and it only works one element deep. See the [React DOM `hydrate` docs]("https://reactjs.org/docs/react-dom.html#hydrate") for more information.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,25 @@ const InternetClock = () => {
 ```
 useInternetTime(
   options?: {
-    fractional?: boolean
+    fractional?: boolean,
+    ssr?: boolean
   }
 ): string
 ```
 
-`useInternetTime` accepts an options argument with one option: `fractional`, which when set to `true` will return with long internet time, e.g. `@230.21`.
+`useInternetTime` accepts an options argument with two values:
+
+### `fractional`
+
+> Default: `false` 
+
+When true, returns a string formatted in long internet time (e.g. `@230.21`). When false, returns a string formatted in short internet time (e.g. `@230`)
+
+### `ssr`
+
+> Default: `false` 
+
+When true, `useInternetTime` will return an empty string on initial render instead of the current time. This makes `useInternetTime` server-side rendering-safe.
+
+This prevents mis-match issues in server-side-rendered environments like Gatsby and Next, where network latency can result in webpage delivery between fractional beats. For example, the server might evaluate to `@230.21` but the client might evaluate to `@230.22`, causing React to error. Enabling this option will prevent this behavior.
+

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "beats"
   ],
   "peerDependencies": {
-    "react": "^16.13.1"
+    "react": "^16.10.2"
   },
   "dependencies": {
     "dot-beat-time": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "use-internet-time",
   "version": "1.0.1",
-  "description": "Add newlines to a string of text given a font style and width",
+  "description": "React Hook for displaying the current time on the internet",
   "main": "src/index.ts",
   "author": "Sam Gwilym <gwilym@me.com>",
   "license": "MIT",
@@ -17,7 +17,6 @@
     "@types/jest": "^24.0.18",
     "@types/react": "^16.9.9",
     "babel-eslint": "^10.0.3",
-    "canvas": "^2.5.0",
     "eslint": "^6.3.0",
     "jest": "^24.9.0",
     "typescript": "^3.5.3"
@@ -47,7 +46,7 @@
     "beats"
   ],
   "peerDependencies": {
-    "react": "^16.10.2"
+    "react": "^16.13.1"
   },
   "dependencies": {
     "dot-beat-time": "^1.2.1"

--- a/src/use-internet-time.ts
+++ b/src/use-internet-time.ts
@@ -1,20 +1,16 @@
-import { useState, useEffect } from "react";
-import { now } from "dot-beat-time";
+import { useState, useEffect } from 'react';
+import { now } from 'dot-beat-time';
 
 type InternetTimeHookOptions = {
   fractional?: boolean;
-  ssr?: boolean;
 };
 
 function useInternetTime(options?: InternetTimeHookOptions) {
   const isFractional = options && options.fractional;
-  const ssr = options && options.ssr;
 
-  const [time, setTime] = useState(ssr ? "" : now(isFractional));
+  const [time, setTime] = useState(now(isFractional));
 
   useEffect(() => {
-    if (ssr) setTime(now(isFractional));
-
     const interval = setInterval(() => {
       setTime(now(isFractional));
     }, 864);
@@ -22,7 +18,7 @@ function useInternetTime(options?: InternetTimeHookOptions) {
     return () => {
       clearInterval(interval);
     };
-  }, [isFractional, ssr]);
+  }, [isFractional]);
 
   return time;
 }

--- a/src/use-internet-time.ts
+++ b/src/use-internet-time.ts
@@ -3,14 +3,18 @@ import { now } from "dot-beat-time";
 
 type InternetTimeHookOptions = {
   fractional?: boolean;
+  ssr?: boolean;
 };
 
 function useInternetTime(options?: InternetTimeHookOptions) {
   const isFractional = options && options.fractional;
+  const ssr = options && options.ssr;
 
-  const [time, setTime] = useState(now(isFractional));
+  const [time, setTime] = useState(ssr ? "" : now(isFractional));
 
   useEffect(() => {
+    if (ssr) setTime(now(isFractional));
+
     const interval = setInterval(() => {
       setTime(now(isFractional));
     }, 864);
@@ -18,7 +22,7 @@ function useInternetTime(options?: InternetTimeHookOptions) {
     return () => {
       clearInterval(interval);
     };
-  }, [isFractional]);
+  }, [isFractional, ssr]);
 
   return time;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1525,15 +1525,6 @@ caniuse-lite@^1.0.30000984:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz#b9193e293ccf7e4426c5245134b8f2a56c0ac4b9"
   integrity sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==
 
-canvas@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.6.0.tgz#7a8f87b6148845d97e6ee30947fba1508bed4941"
-  integrity sha512-bEO9f1ThmbknLPxCa8Es7obPlN9W3stB1bo7njlhOFKIdUTldeTqXCh9YclCPAi2pSQs84XA0jq/QEZXSzgyMw==
-  dependencies:
-    nan "^2.14.0"
-    node-pre-gyp "^0.11.0"
-    simple-get "^3.0.3"
-
 capture-exit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
@@ -1880,13 +1871,6 @@ decompress-response@^3.3.0:
   integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
   dependencies:
     mimic-response "^1.0.0"
-
-decompress-response@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
-  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
-  dependencies:
-    mimic-response "^2.0.0"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -4083,11 +4067,6 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-mimic-response@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.0.0.tgz#996a51c60adf12cb8a87d7fb8ef24c2f3d5ebb46"
-  integrity sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==
-
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -4168,7 +4147,7 @@ mute-stream@0.0.8:
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.12.1, nan@^2.14.0:
+nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
@@ -4234,22 +4213,6 @@ node-notifier@^5.4.2:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
-
-node-pre-gyp@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz#db1f33215272f692cd38f03238e3e9b47c5dd054"
-  integrity sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4"
 
 node-pre-gyp@^0.12.0:
   version "0.12.0"
@@ -5340,20 +5303,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
-
-simple-concat@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
-  integrity sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=
-
-simple-get@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.0.tgz#b45be062435e50d159540b576202ceec40b9c6b3"
-  integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
-  dependencies:
-    decompress-response "^4.2.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
 
 sisteransi@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
## Short version

- Adds `ssr` config option to support server-side rendering
- Updates `README.md` to document how the `ssr` option works
- Removes Canvas dev dependency, since it isn't used by anything (and was breaking my local install)
- Updates the package description to match the package!

## Long version

Thanks a bunch for making this hook! 

### SSR support

I recently tried to use it in a Next.js app, but I ran into some problems with fractional time and server-side rendering. I found that it was pretty common for the server-side render and the client-side hydration to be a hundredth of a beat off from each other, so React complained about mismatching text.

To fix this, I added an SSR flag to the config object, that prevents setting the default state of `time` when enabled, and instead immediately sets the current time at the start of the `useEffect`. Since `useEffect` isn't run during the server-side pass, the time will evaluate to an empty string in both places on initial render.

I've also updated the README to reflect this option.

#### Alternate solution

If this seems a bit too absurd (and it kinda does), we might consider _always_ setting the initial state of `time` to an empty string and _always_ setting the initial time at the start of the `useEffect` hook. This would make `useInternetTime` 100% server-side rendering safe at all times, and we could forego this config option.

I think this approach makes sense from a best-practices standpoint, because we're dealing with time. We're just lucky when the server-side pass matches the client-side pass. The only problem with this implementation is that **users might see a flash of an empty string on initial render.** It's likely that this would be imperceivable, though, since we would basically be moving the state initialization two lines down.

I didn't want to make the call for you, though. If you think the empty string initialization is acceptable, awesome, I'll update this PR to implement that! If not, then the SSR option is the best way to go, and developers can opt-in to the flash of empty text.

### Other fixes

I updated the description of the package since it didn't reflect the actual package's offering.

I removed the Canvas dev dependency, because it was having strange issues with node-gyp on my machine, and it doesn't seem to be required by any of the other dev depencencies.

I updated the React peer dependency (by accident, I guess 😅) to 16.13.x, but I can revert that if you want.